### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ To install in R, first install the package devtools from CRAN and then run
 
 ```
 library(devtools);
-install_github(repo="dplyrExtras", username="skranz")
+install_github(repo="skranz/dplyrExtras")
 ```


### PR DESCRIPTION
Need to fix the install due to Username being deprecated.

> Warning message:
> Username parameter is deprecated. Please use skranz/dplyrExtras 

I edited it to be:
`install_github(repo="skranz/dplyrExtras")`
